### PR TITLE
Fix a bug causing saleforce import to fail

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -400,7 +400,8 @@ def do_discover_object(sf):
         'stream': sobject_name,
         'tap_stream_id': sobject_name,
         'schema': schema,
-        'metadata': metadata.to_list(mdata)
+        'metadata': metadata.to_list(mdata),
+        'column_order': [str(column) for column in properties]
     }
 
     entries.append(entry)


### PR DESCRIPTION
'column_order' should be added to the catalog when doing discovery, otherwise it would be missing during import.

app pr: https://github.com/symon-ai/app/pull/4742
v2.0.7 should be created.