### PR TITLE
WP-7467 Use the tap_stream_id for syncing data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-salesforce"
-version = "2.0.8"
+version = "2.0.9"
 description = "Singer.io tap for extracting data from the Salesforce API"
 authors = ["Stitch"]
 homepage = "https://singer.io"

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -433,7 +433,7 @@ def do_sync(sf, catalog, state):
     for catalog_entry in catalog["streams"]:
         stream_version = get_stream_version(catalog_entry, state)
         stream = catalog_entry['stream']
-        stream_id = catalog_entry['tap_stream_id']
+        stream_id = (catalog_entry['tap_stream_id'] or stream)
         stream_alias = catalog_entry.get('stream_alias')
         stream_name = catalog_entry["tap_stream_id"]
         activate_version_message = singer.ActivateVersionMessage(

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -433,6 +433,7 @@ def do_sync(sf, catalog, state):
     for catalog_entry in catalog["streams"]:
         stream_version = get_stream_version(catalog_entry, state)
         stream = catalog_entry['stream']
+        stream_id = catalog_entry['tap_stream_id']
         stream_alias = catalog_entry.get('stream_alias')
         stream_name = catalog_entry["tap_stream_id"]
         activate_version_message = singer.ActivateVersionMessage(
@@ -462,7 +463,7 @@ def do_sync(sf, catalog, state):
         key_properties = metadata.to_map(catalog_entry['metadata']).get(
             (), {}).get('table-key-properties')
         singer.write_schema(
-            stream,
+            stream_id,
             catalog_entry['schema'],
             key_properties,
             replication_key,

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -61,6 +61,7 @@ def resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter):
 
     start_time = singer_utils.now()
     stream = catalog_entry['stream']
+    stream_id = catalog_entry['tap_stream_id']
     stream_alias = catalog_entry.get('stream_alias')
     catalog_metadata = metadata.to_map(catalog_entry.get('metadata'))
     replication_key = catalog_metadata.get((), {}).get('replication-key')
@@ -81,8 +82,7 @@ def resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter):
                 rec = fix_record_anytype(rec, schema)
                 singer.write_message(
                     singer.RecordMessage(
-                        stream=(
-                            stream_alias or stream),
+                        stream=(stream_id or stream_alias or stream),
                         record=rec,
                         version=stream_version,
                         time_extracted=start_time))
@@ -131,6 +131,7 @@ def sync_records(sf, catalog_entry, state, counter):
     chunked_bookmark = singer_utils.strptime_with_tz(
         sf.get_start_date(state, catalog_entry))
     stream = catalog_entry['stream']
+    stream_id = catalog_entry['tap_stream_id']
     schema = catalog_entry['schema']
     stream_alias = catalog_entry.get('stream_alias')
     catalog_metadata = metadata.to_map(catalog_entry['metadata'])
@@ -150,8 +151,7 @@ def sync_records(sf, catalog_entry, state, counter):
         rec = fix_record_anytype(rec, schema)
         singer.write_message(
             singer.RecordMessage(
-                stream=(
-                    stream_alias or stream),
+                stream=(stream_id or stream_alias or stream),
                 record=rec,
                 version=stream_version,
                 time_extracted=start_time))
@@ -209,12 +209,13 @@ def sync_report(sf, catalog_entry, state, counter):
     chunked_bookmark = singer_utils.strptime_with_tz(
         sf.get_start_date(state, catalog_entry))
     stream = catalog_entry['stream']
+    stream_id = catalog_entry['tap_stream_id']
     schema = catalog_entry['schema']
     stream_alias = catalog_entry.get('stream_alias')
     catalog_metadata = metadata.to_map(catalog_entry['metadata'])
     replication_key = catalog_metadata.get((), {}).get('replication-key')
     stream_version = get_stream_version(catalog_entry, state)
-    activate_version_message = singer.ActivateVersionMessage(stream=(stream_alias or stream),
+    activate_version_message = singer.ActivateVersionMessage(stream=(stream_id or stream_alias or stream),
                                                              version=stream_version)
 
     start_time = singer_utils.now()
@@ -229,8 +230,7 @@ def sync_report(sf, catalog_entry, state, counter):
 
         singer.write_message(
             singer.RecordMessage(
-                stream=(
-                    stream_alias or stream),
+                stream=(stream_id or stream_alias or stream),
                 record=rec,
                 version=stream_version,
                 time_extracted=start_time))

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -215,7 +215,7 @@ def sync_report(sf, catalog_entry, state, counter):
     catalog_metadata = metadata.to_map(catalog_entry['metadata'])
     replication_key = catalog_metadata.get((), {}).get('replication-key')
     stream_version = get_stream_version(catalog_entry, state)
-    activate_version_message = singer.ActivateVersionMessage(stream=(stream_id or stream_alias or stream),
+    activate_version_message = singer.ActivateVersionMessage(stream=(stream_alias or stream),
                                                              version=stream_version)
 
     start_time = singer_utils.now()


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-7467

Use the tap_stream_id for data syncing. Stream and tap_stream_id are not equal for tap_salesforce:reports so the tap_stream_id needs to be used if possible. 