### PR TITLE
WP-9908 rows feature is NoneType when detail rows is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.13
+
+- Handle side case for reports importing when the `detail rows` feature is not selected in salesforce reports 
+
 ## 2.0.12
 
 - Merge latest from singer-io/tap-salesforce

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-salesforce"
-version = "2.0.12"
+version = "2.0.13"
 description = "Singer.io tap for extracting data from the Salesforce API"
 authors = ["Stitch"]
 homepage = "https://singer.io"

--- a/tap_salesforce/salesforce/report_rest.py
+++ b/tap_salesforce/salesforce/report_rest.py
@@ -43,6 +43,7 @@ class ReportRest():
             resp = self.sf._make_request(
                 'POST', url, headers=headers, body=json.dumps(body))
             resp_json = resp.json()
+            # T!T rows feature only exists when detail feature is selected in salesforce reports
             report_results = resp_json.get('factMap').get("T!T").get('rows')
             detail_column_info = resp_json.get(
                 'reportExtendedMetadata').get('detailColumnInfo')
@@ -60,6 +61,9 @@ class ReportRest():
 
     def __transform_report_api_result(self, report_results, detail_columns, detail_column_info):
         # Transform and cleanup results
+        # if detail rows is not selected, report_results will be NoneType
+        if report_results == None: return []
+
         results = []
         for row in report_results:
             data_cell = row['dataCells']

--- a/tap_salesforce/salesforce/report_rest.py
+++ b/tap_salesforce/salesforce/report_rest.py
@@ -60,10 +60,10 @@ class ReportRest():
             raise ex
 
     def __transform_report_api_result(self, report_results, detail_columns, detail_column_info):
-        # Transform and cleanup results
         # if detail rows is not selected, report_results will be NoneType
         if report_results == None: return []
 
+        # Transform and cleanup results
         results = []
         for row in report_results:
             data_cell = row['dataCells']

--- a/tap_salesforce/salesforce/report_rest.py
+++ b/tap_salesforce/salesforce/report_rest.py
@@ -61,7 +61,9 @@ class ReportRest():
 
     def __transform_report_api_result(self, report_results, detail_columns, detail_column_info):
         # if detail rows is not selected, report_results will be NoneType
-        if report_results == None: return []
+        # WP-9908, the error message will be handled in WP-10193
+        if report_results == None:
+            raise Exception("Report response is missing rows feature in factMap, could be related to detail rows feature is not selected in Salesforce")
 
         # Transform and cleanup results
         results = []

--- a/tap_salesforce/salesforce/report_rest.py
+++ b/tap_salesforce/salesforce/report_rest.py
@@ -63,7 +63,7 @@ class ReportRest():
         # if detail rows is not selected, report_results will be NoneType
         # WP-9908, the error message will be handled in WP-10193
         if report_results == None:
-            raise Exception("Report response is missing rows feature in factMap, could be related to detail rows feature is not selected in Salesforce")
+            raise Exception("The Report response is missing the rows feature in factMap, check that the detail rows feature is selected in Salesforce")
 
         # Transform and cleanup results
         results = []


### PR DESCRIPTION
# Description of change
[(write a short description here or paste a link to JIRA)
](https://varicent.atlassian.net/browse/WP-9908)

In the environment `https://symon-ai-august-test-org.my.salesforce.com/`, the import will fail for some of the reports (`Opportunity` and `Accounts`), checking the difference with the imports that are being able to import, the `detail rows` feature needs to be selected.

Update `__transform_report_api_result` to take care of side case when `T!T/rows` is NoneType