### PR TITLE
WP-24138: 00260676 - Human Security - ELT is not refreshing data sources to import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-salesforce"
-version = "3.1.0"
+version = "3.2.0"
 description = "Singer.io tap for extracting data from the Salesforce API"
 authors = ["Stitch"]
 homepage = "https://singer.io"

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -609,6 +609,7 @@ def main_impl():
             do_sync(sf, catalog, state)
     except SymonException as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+        
         error_info = {
             'message': traceback.format_exception_only(exc_type, exc_value)[-1],
             'code': e.code,
@@ -623,7 +624,7 @@ def main_impl():
         error_info = {
             'message': traceback.format_exception_only(exc_type, exc_value)[-1],
             'traceback': "".join(traceback.format_tb(exc_traceback))
-        }
+        }        
         raise
     finally:
         if error_info is not None:

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -609,7 +609,6 @@ def main_impl():
             do_sync(sf, catalog, state)
     except SymonException as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        
         error_info = {
             'message': traceback.format_exception_only(exc_type, exc_value)[-1],
             'code': e.code,
@@ -624,7 +623,7 @@ def main_impl():
         error_info = {
             'message': traceback.format_exception_only(exc_type, exc_value)[-1],
             'traceback': "".join(traceback.format_tb(exc_traceback))
-        }        
+        }
         raise
     finally:
         if error_info is not None:

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -141,6 +141,11 @@ def sync_stream(sf, catalog_entry, state):
             raise
         except Exception as ex:
             message = str(ex)
+            if any(phrase in message for phrase in (
+                "total REST quota used across all Salesforce Applications",
+                "Terminating replication due to allotted"
+            )):
+                raise
             if "OPERATION_TOO_LARGE: exceeded 100000 distinct who/what's" in message:
                 raise SingerSyncError("OPERATION_TOO_LARGE: exceeded 100000 distinct who/what's. " +
                                       "Consider asking your Salesforce System Administrator to provide you with the " +


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-24138

Issue: when you refresh a salesforce import, if the total rest quota is full is will fail but will not return error to user. This is caused by tap-salesforce goes to sync, when an error happens here it has to go through an additional filter, if no filter is specificied it will go to: raise Exception("{}, (Stream: {})".format(
                ex, stream)) from ex
                
(If it goes here it will not return error code which will prevent it from being shown to the user.

Solution added a check to let it pass without being changed. 